### PR TITLE
Add content length warning in notion.py

### DIFF
--- a/notion.py
+++ b/notion.py
@@ -76,7 +76,9 @@ def update_page(page_id, **kwargs):
     return process_response(res), res.json()
 
 
-def process_response(res, log=False):
+def process_response(res, content_length_limit=2000, log=False):
+    if len(res.content) > content_length_limit:
+        _LOG.warning(f'Content length exceeded {content_length_limit} characters.')
     if res.status_code != 200:
         _LOG.error(f"Got response for {res.request.method} {res.request.url}")
         _LOG.error(f"Error message: {json.dumps(res.json(), ensure_ascii=False, indent=2)}")


### PR DESCRIPTION
This pull request addresses the issue #5 by adding a warning log in the `process_response` function of `notion.py` when the content length exceeds 2000 characters. This ensures that users are warned about potential issues with large content blocks saved to Notion.